### PR TITLE
Update for uber-cache 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 { "author": "Paul Serby <paul@serby.net>"
 , "name": "uber-cache-redis"
 , "description": "Redis Engine for uber-cache"
-, "version": "0.0.1"
+, "version": "0.1.0"
 , "tags":
   [ "cache"
   , "memory"
@@ -23,6 +23,6 @@
 , "devDependencies":
   { "mocha": "*"
   , "should": "*"
-  , "uber-cache": "*"
+  , "uber-cache": ">= 0.2.0"
   }
 }

--- a/redisEngine.js
+++ b/redisEngine.js
@@ -1,51 +1,60 @@
 var _ = require('underscore')
+  , EventEmitter = require('events').EventEmitter
   , redis = require('redis');
 
 module.exports = function(options) {
 
-  var client = redis.createClient();
+  var client = redis.createClient()
+    , handle = new EventEmitter();
 
-  client.on('error', function (err) {
-    console.log('Redis Error: ' + err);
+  client.on('error', function(err) {
+    handle.emit('error', err);
   });
 
-  options = _.extend({
-    size: 1000 // Maximum number of items that can be held in the LRU cache.
-  }, options);
+  handle.set = function(key, value, ttl, callback) {
+    if (typeof ttl === 'function') {
+      callback = ttl;
+      ttl = undefined;
+    }
 
-  function clear() {
-    client.flushdb();
-  }
+    if (typeof key === 'undefined') {
+      var err = new Error('Invalid key undefined');
+      handle.emit('error', err);
+      throw err;
+    }
 
-  function del(key, callback) {
-    client.del(key, callback);
-  }
-
-  return {
-    set: function(key, value, ttl, callback) {
-      if (typeof ttl === 'function') {
-        callback = ttl;
-        ttl = undefined;
-      }
-      if (typeof key === 'undefined') {
-        throw new Error('Invalid key undefined');
-      }
-      if ((typeof(ttl) === 'number') && (parseInt(ttl, 10) === ttl)) {
-        client.setex(key, ttl, value, callback);
-      } else {
-        client.set(key, value, callback);
-      }
-    },
-    get: function(key, callback) {
-      return client.get(key, callback);
-    },
-    del: del,
-    clear: clear,
-    size: function(callback) {
-      client.dbsize(callback);
-    },
-    dump: function() {
-      //?
+    if ((typeof(ttl) === 'number') && (parseInt(ttl, 10) === ttl)) {
+      client.setex(key, ttl, value, callback);
+    } else {
+      client.set(key, value, callback);
     }
   };
+
+  handle.get = function(key, callback) {
+    return client.get(key, function(err, value) {
+      if (value === null) {
+        handle.emit('miss', key);
+      }
+
+      callback(err, value);
+    });
+  };
+
+  handle.del = function(key, callback) {
+    client.del(key, callback);
+  };
+
+  handle.clear = function() {
+    client.flushdb();
+  };
+
+  handle.size = function(callback) {
+    client.dbsize(callback);
+  };
+
+  handle.dump = function(callback) {
+    // ?
+  };
+
+  return handle;
 };


### PR DESCRIPTION
- Stream support has been removed.
- All values are JSON-encoded/decoded.
